### PR TITLE
【Middleware】認証ミドルウェアを作成

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -23,17 +23,12 @@ paths:
         500:
           description: "サーバーエラー"
           $ref: "#/components/responses/500"
-  /users/{name}:
     put:
       summary: "ユーザー更新"
       tags:
         - "users"
-      parameters:
-        - in: "path"
-          name: "name"
-          required: true
-          schema:
-            $ref: "#/components/schemas/user/properties/name"
+      security:
+        - bearerAuth: []
       requestBody:
         $ref: "#/components/requestBodies/update_user"
       responses:
@@ -53,12 +48,8 @@ paths:
       summary: "ユーザー削除"
       tags:
         - "users"
-      parameters:
-        - in: "path"
-          name: "name"
-          required: true
-          schema:
-            $ref: "#/components/schemas/user/properties/name"
+      security:
+        - bearerAuth: []
       requestBody:
         $ref: "#/components/requestBodies/delete_user"
       responses:

--- a/internal/app/api/domain/repository/user.go
+++ b/internal/app/api/domain/repository/user.go
@@ -5,11 +5,14 @@ import (
 	"context"
 	"holos-auth-api/internal/app/api/domain/entity"
 	"holos-auth-api/internal/pkg/apierr"
+
+	"github.com/google/uuid"
 )
 
 type UserRepository interface {
 	Create(context.Context, *entity.User) apierr.ApiError
 	Update(context.Context, *entity.User) apierr.ApiError
 	Delete(context.Context, *entity.User) apierr.ApiError
+	FindOneByID(context.Context, uuid.UUID) (*entity.User, apierr.ApiError)
 	FindOneByName(context.Context, string) (*entity.User, apierr.ApiError)
 }

--- a/internal/app/api/injection.go
+++ b/internal/app/api/injection.go
@@ -4,12 +4,15 @@ import (
 	"holos-auth-api/internal/app/api/domain/service"
 	"holos-auth-api/internal/app/api/infrastructure"
 	"holos-auth-api/internal/app/api/interface/handler"
+	"holos-auth-api/internal/app/api/interface/middleware"
 	"holos-auth-api/internal/app/api/usecase"
 
 	"github.com/jmoiron/sqlx"
 )
 
 var (
+	authMiddleware middleware.AuthMiddleware
+
 	userHandler handler.UserHandler
 	authHandler handler.AuthHandler
 )
@@ -24,6 +27,8 @@ func inject(db *sqlx.DB) {
 
 	userUsecase := usecase.NewUserUsecase(transactionObject, userInfrastructure, userService)
 	authUsecase := usecase.NewAuthUsecase(transactionObject, userInfrastructure, userTokenInfrastructure)
+
+	authMiddleware = middleware.NewAuthMiddleware(authUsecase)
 
 	userHandler = handler.NewUserHandler(userUsecase)
 	authHandler = handler.NewAuthHandler(authUsecase)

--- a/internal/app/api/interface/handler/user.go
+++ b/internal/app/api/interface/handler/user.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 )
 
 type UserHandler interface {
@@ -51,9 +52,20 @@ func (uh *userHandler) Update(c *gin.Context) {
 		return
 	}
 
+	userID, exists := c.Get("userID")
+	if !exists {
+		c.String(http.StatusInternalServerError, "context does not have user id")
+		return
+	}
+
+	id, ok := userID.(uuid.UUID)
+	if !ok {
+		c.String(http.StatusInternalServerError, "Invalid user id type")
+	}
+
 	ctx := context.Background()
 
-	dto, err := uh.userUsecase.Update(ctx, c.Param("name"), req.CurrentPassword, req.NewPassword, req.ConfirmNewPassword)
+	dto, err := uh.userUsecase.Update(ctx, id, req.CurrentPassword, req.NewPassword, req.ConfirmNewPassword)
 	if err != nil {
 		c.String(err.Error())
 		return
@@ -69,9 +81,20 @@ func (uh *userHandler) Delete(c *gin.Context) {
 		return
 	}
 
+	userID, exists := c.Get("userID")
+	if !exists {
+		c.String(http.StatusInternalServerError, "context does not have user id")
+		return
+	}
+
+	id, ok := userID.(uuid.UUID)
+	if !ok {
+		c.String(http.StatusInternalServerError, "Invalid user id type")
+	}
+
 	ctx := context.Background()
 
-	if err := uh.userUsecase.Delete(ctx, c.Param("name"), req.Password); err != nil {
+	if err := uh.userUsecase.Delete(ctx, id, req.Password); err != nil {
 		c.String(err.Error())
 		return
 	}

--- a/internal/app/api/interface/handler/user_test.go
+++ b/internal/app/api/interface/handler/user_test.go
@@ -77,32 +77,44 @@ func TestUser_Create(t *testing.T) {
 func TestUser_Update(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	tests := []struct {
-		name        string
-		requestJSON string
-		resultDTO   *dto.UserDTO
-		resultError apierr.ApiError
-		expect      int
+		name                 string
+		isSetUserIDToContext bool
+		requestJSON          string
+		resultDTO            *dto.UserDTO
+		resultError          apierr.ApiError
+		expect               int
 	}{
 		{
-			name:        "success",
-			requestJSON: `{"current_password": "password", "new_password": "new_password", "confirm_new_password": "new_password"}`,
-			resultDTO:   dto.NewUserDTO(uuid.New(), "name", "password", time.Now(), time.Now()),
-			resultError: nil,
-			expect:      http.StatusOK,
+			name:                 "success",
+			isSetUserIDToContext: true,
+			requestJSON:          `{"current_password": "password", "new_password": "new_password", "confirm_new_password": "new_password"}`,
+			resultDTO:            dto.NewUserDTO(uuid.New(), "name", "password", time.Now(), time.Now()),
+			resultError:          nil,
+			expect:               http.StatusOK,
 		},
 		{
-			name:        "invalid_request",
-			requestJSON: "",
-			resultDTO:   dto.NewUserDTO(uuid.New(), "name", "password", time.Now(), time.Now()),
-			resultError: nil,
-			expect:      http.StatusBadRequest,
+			name:                 "context_does_not_have_user_id",
+			isSetUserIDToContext: false,
+			requestJSON:          `{"current_password": "password", "new_password": "new_password", "confirm_new_password": "new_password"}`,
+			resultDTO:            dto.NewUserDTO(uuid.New(), "name", "password", time.Now(), time.Now()),
+			resultError:          nil,
+			expect:               http.StatusInternalServerError,
 		},
 		{
-			name:        "result_error",
-			requestJSON: `{"current_password": "password", "new_password": "new_password", "confirm_new_password": "new_password"}`,
-			resultDTO:   nil,
-			resultError: apierr.NewApiError(http.StatusInternalServerError, "test error"),
-			expect:      http.StatusInternalServerError,
+			name:                 "invalid_request",
+			isSetUserIDToContext: true,
+			requestJSON:          "",
+			resultDTO:            dto.NewUserDTO(uuid.New(), "name", "password", time.Now(), time.Now()),
+			resultError:          nil,
+			expect:               http.StatusBadRequest,
+		},
+		{
+			name:                 "result_error",
+			isSetUserIDToContext: true,
+			requestJSON:          `{"current_password": "password", "new_password": "new_password", "confirm_new_password": "new_password"}`,
+			resultDTO:            nil,
+			resultError:          apierr.NewApiError(http.StatusInternalServerError, "test error"),
+			expect:               http.StatusInternalServerError,
 		},
 	}
 	for _, tt := range tests {
@@ -116,6 +128,9 @@ func TestUser_Update(t *testing.T) {
 			ctx, _ := gin.CreateTestContext(w)
 			ctx.Request = req
 			ctx.Params = append(ctx.Params, gin.Param{Key: "name", Value: tt.name})
+			if tt.isSetUserIDToContext {
+				ctx.Set("userID", uuid.New())
+			}
 
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -136,29 +151,41 @@ func TestUser_Update(t *testing.T) {
 func TestUser_Delete(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	tests := []struct {
-		name        string
-		requestJSON string
-		resultDTO   *dto.UserDTO
-		resultError apierr.ApiError
-		expect      int
+		name                 string
+		isSetUserIDToContext bool
+		requestJSON          string
+		resultDTO            *dto.UserDTO
+		resultError          apierr.ApiError
+		expect               int
 	}{
 		{
-			name:        "success",
-			requestJSON: `{"password": "password"}`,
-			resultError: nil,
-			expect:      http.StatusOK,
+			name:                 "success",
+			isSetUserIDToContext: true,
+			requestJSON:          `{"password": "password"}`,
+			resultError:          nil,
+			expect:               http.StatusOK,
 		},
 		{
-			name:        "invalid_request",
-			requestJSON: "",
-			resultError: nil,
-			expect:      http.StatusBadRequest,
+			name:                 "context_does_not_have_user_id",
+			isSetUserIDToContext: false,
+			requestJSON:          `{"current_password": "password", "new_password": "new_password", "confirm_new_password": "new_password"}`,
+			resultDTO:            dto.NewUserDTO(uuid.New(), "name", "password", time.Now(), time.Now()),
+			resultError:          nil,
+			expect:               http.StatusInternalServerError,
 		},
 		{
-			name:        "result_error",
-			requestJSON: `{"password": "password"}`,
-			resultError: apierr.NewApiError(http.StatusInternalServerError, "test error"),
-			expect:      http.StatusInternalServerError,
+			name:                 "invalid_request",
+			isSetUserIDToContext: true,
+			requestJSON:          "",
+			resultError:          nil,
+			expect:               http.StatusBadRequest,
+		},
+		{
+			name:                 "result_error",
+			isSetUserIDToContext: true,
+			requestJSON:          `{"password": "password"}`,
+			resultError:          apierr.NewApiError(http.StatusInternalServerError, "test error"),
+			expect:               http.StatusInternalServerError,
 		},
 	}
 	for _, tt := range tests {
@@ -172,6 +199,9 @@ func TestUser_Delete(t *testing.T) {
 			ctx, _ := gin.CreateTestContext(w)
 			ctx.Request = req
 			ctx.Params = append(ctx.Params, gin.Param{Key: "name", Value: tt.name})
+			if tt.isSetUserIDToContext {
+				ctx.Set("userID", uuid.New())
+			}
 
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()

--- a/internal/app/api/interface/middleware/auth.go
+++ b/internal/app/api/interface/middleware/auth.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"errors"
 	"holos-auth-api/internal/app/api/usecase"
 	"net/http"
 	"strings"
@@ -27,7 +26,8 @@ func NewAuthMiddleware(authUsecase usecase.AuthUsecase) AuthMiddleware {
 func (am *authMiddleware) Authenticate(c *gin.Context) {
 	bearerToken := strings.Split(c.Request.Header.Get("Authorization"), " ")
 	if len(bearerToken) != 2 || bearerToken[0] != "Bearer" {
-		c.AbortWithError(http.StatusUnauthorized, errors.New("unauthorized"))
+		c.String(http.StatusUnauthorized, "unauthorized")
+		c.Abort()
 		return
 	}
 
@@ -35,8 +35,8 @@ func (am *authMiddleware) Authenticate(c *gin.Context) {
 
 	userID, err := am.authUsecase.GetUserID(ctx, bearerToken[1])
 	if len(bearerToken) != 2 || bearerToken[0] != "Bearer" {
-		code, msg := err.Error()
-		c.AbortWithError(code, errors.New(msg))
+		c.String(err.Error())
+		c.Abort()
 		return
 	}
 

--- a/internal/app/api/interface/middleware/auth.go
+++ b/internal/app/api/interface/middleware/auth.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"holos-auth-api/internal/app/api/usecase"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+type AuthMiddleware interface {
+	Authenticate(*gin.Context)
+}
+
+type authMiddleware struct {
+	authUsecase usecase.AuthUsecase
+}
+
+func NewAuthMiddleware(authUsecase usecase.AuthUsecase) AuthMiddleware {
+	return &authMiddleware{
+		authUsecase: authUsecase,
+	}
+}
+
+func (am *authMiddleware) Authenticate(c *gin.Context) {
+	bearerToken := strings.Split(c.Request.Header.Get("Authorization"), " ")
+	if len(bearerToken) != 2 || bearerToken[0] != "Bearer" {
+		c.AbortWithError(http.StatusUnauthorized, errors.New("unauthorized"))
+		return
+	}
+
+	ctx := context.Background()
+
+	userID, err := am.authUsecase.GetUserID(ctx, bearerToken[1])
+	if len(bearerToken) != 2 || bearerToken[0] != "Bearer" {
+		code, msg := err.Error()
+		c.AbortWithError(code, errors.New(msg))
+		return
+	}
+
+	c.Set("userID", userID)
+	c.Next()
+}

--- a/internal/app/api/router.go
+++ b/internal/app/api/router.go
@@ -6,8 +6,8 @@ func getRoutes(r *gin.Engine) {
 	users := r.Group("users")
 	{
 		users.POST("/", userHandler.Create)
-		users.PUT("/:name", userHandler.Update)
-		users.DELETE("/:name", userHandler.Delete)
+		users.PUT("/", authMiddleware.Authenticate, userHandler.Update)
+		users.DELETE("/", authMiddleware.Authenticate, userHandler.Delete)
 	}
 
 	auth := r.Group("auth")

--- a/internal/app/api/usecase/user.go
+++ b/internal/app/api/usecase/user.go
@@ -10,6 +10,8 @@ import (
 	"holos-auth-api/internal/app/api/usecase/dto"
 	"holos-auth-api/internal/pkg/apierr"
 	"net/http"
+
+	"github.com/google/uuid"
 )
 
 var (
@@ -19,8 +21,8 @@ var (
 
 type UserUsecase interface {
 	Create(context.Context, string, string, string) (*dto.UserDTO, apierr.ApiError)
-	Update(context.Context, string, string, string, string) (*dto.UserDTO, apierr.ApiError)
-	Delete(context.Context, string, string) apierr.ApiError
+	Update(context.Context, uuid.UUID, string, string, string) (*dto.UserDTO, apierr.ApiError)
+	Delete(context.Context, uuid.UUID, string) apierr.ApiError
 }
 
 type userUsecase struct {
@@ -58,12 +60,12 @@ func (uu *userUsecase) Create(ctx context.Context, name string, password string,
 	return dto.NewUserDTO(user.ID, user.Name, user.Password, user.CreatedAt, user.UpdatedAt), nil
 }
 
-func (uu *userUsecase) Update(ctx context.Context, name string, currentPassword string, newPassword string, confirmNewPassword string) (*dto.UserDTO, apierr.ApiError) {
+func (uu *userUsecase) Update(ctx context.Context, id uuid.UUID, currentPassword string, newPassword string, confirmNewPassword string) (*dto.UserDTO, apierr.ApiError) {
 	var user *entity.User
 
 	if err := uu.transactionObject.Transaction(ctx, func(ctx context.Context) apierr.ApiError {
 		var err apierr.ApiError
-		user, err = uu.userRepository.FindOneByName(ctx, name)
+		user, err = uu.userRepository.FindOneByID(ctx, id)
 		if err != nil {
 			return err
 		}
@@ -87,9 +89,9 @@ func (uu *userUsecase) Update(ctx context.Context, name string, currentPassword 
 	return dto.NewUserDTO(user.ID, user.Name, user.Password, user.CreatedAt, user.UpdatedAt), nil
 }
 
-func (uu *userUsecase) Delete(ctx context.Context, name string, password string) apierr.ApiError {
+func (uu *userUsecase) Delete(ctx context.Context, id uuid.UUID, password string) apierr.ApiError {
 	return uu.transactionObject.Transaction(ctx, func(ctx context.Context) apierr.ApiError {
-		user, err := uu.userRepository.FindOneByName(ctx, name)
+		user, err := uu.userRepository.FindOneByID(ctx, id)
 		if err != nil {
 			return err
 		}

--- a/internal/app/api/usecase/user_test.go
+++ b/internal/app/api/usecase/user_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 )
 
 func TestUser_Create(t *testing.T) {
@@ -67,18 +68,21 @@ func TestUser_Create(t *testing.T) {
 
 func TestUser_Update(t *testing.T) {
 	tests := []struct {
+		id          uuid.UUID
 		name        string
 		password    string
 		isReturnNil bool
 		expect      apierr.ApiError
 	}{
 		{
+			id:          uuid.New(),
 			name:        "exists",
 			password:    "password",
 			isReturnNil: false,
 			expect:      nil,
 		},
 		{
+			id:          uuid.New(),
 			name:        "not_exists",
 			password:    "password",
 			isReturnNil: true,
@@ -111,7 +115,7 @@ func TestUser_Update(t *testing.T) {
 			us := mock_service.NewMockUserService(ctrl)
 
 			uu := usecase.NewUserUsecase(to, ur, us)
-			dto, err := uu.Update(ctx, tt.name, tt.password, tt.password, tt.password)
+			dto, err := uu.Update(ctx, tt.id, tt.password, tt.password, tt.password)
 			if err != tt.expect {
 				if err == nil {
 					t.Error("expect err but got nil")
@@ -128,18 +132,21 @@ func TestUser_Update(t *testing.T) {
 
 func TestUser_Delete(t *testing.T) {
 	tests := []struct {
+		id          uuid.UUID
 		name        string
 		password    string
 		isReturnNil bool
 		expect      apierr.ApiError
 	}{
 		{
+			id:          uuid.New(),
 			name:        "exists",
 			password:    "password",
 			isReturnNil: false,
 			expect:      nil,
 		},
 		{
+			id:          uuid.New(),
 			name:        "not_exists",
 			password:    "password",
 			isReturnNil: true,
@@ -172,7 +179,7 @@ func TestUser_Delete(t *testing.T) {
 			us := mock_service.NewMockUserService(ctrl)
 
 			uu := usecase.NewUserUsecase(to, ur, us)
-			err = uu.Delete(ctx, tt.name, tt.password)
+			err = uu.Delete(ctx, tt.id, tt.password)
 			if err != tt.expect {
 				if err == nil {
 					t.Error("expect err but got nil")

--- a/internal/app/api/usecase/user_test.go
+++ b/internal/app/api/usecase/user_test.go
@@ -109,7 +109,7 @@ func TestUser_Update(t *testing.T) {
 			to := test.NewTestTransactionObject()
 
 			ur := mock_repository.NewMockUserRepository(ctrl)
-			ur.EXPECT().FindOneByName(ctx, tt.name).Return(res, nil)
+			ur.EXPECT().FindOneByID(ctx, tt.id).Return(res, nil)
 			ur.EXPECT().Update(ctx, gomock.Any()).Return(nil).AnyTimes()
 
 			us := mock_service.NewMockUserService(ctrl)
@@ -173,7 +173,7 @@ func TestUser_Delete(t *testing.T) {
 			to := test.NewTestTransactionObject()
 
 			ur := mock_repository.NewMockUserRepository(ctrl)
-			ur.EXPECT().FindOneByName(ctx, tt.name).Return(res, nil)
+			ur.EXPECT().FindOneByID(ctx, tt.id).Return(res, nil)
 			ur.EXPECT().Delete(ctx, gomock.Any()).Return(nil).AnyTimes()
 
 			us := mock_service.NewMockUserService(ctrl)

--- a/test/mock/domain/repository/user.go
+++ b/test/mock/domain/repository/user.go
@@ -11,6 +11,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	uuid "github.com/google/uuid"
 )
 
 // MockUserRepository is a mock of UserRepository interface.
@@ -62,6 +63,21 @@ func (m *MockUserRepository) Delete(arg0 context.Context, arg1 *entity.User) api
 func (mr *MockUserRepositoryMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockUserRepository)(nil).Delete), arg0, arg1)
+}
+
+// FindOneByID mocks base method.
+func (m *MockUserRepository) FindOneByID(arg0 context.Context, arg1 uuid.UUID) (*entity.User, apierr.ApiError) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindOneByID", arg0, arg1)
+	ret0, _ := ret[0].(*entity.User)
+	ret1, _ := ret[1].(apierr.ApiError)
+	return ret0, ret1
+}
+
+// FindOneByID indicates an expected call of FindOneByID.
+func (mr *MockUserRepositoryMockRecorder) FindOneByID(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneByID", reflect.TypeOf((*MockUserRepository)(nil).FindOneByID), arg0, arg1)
 }
 
 // FindOneByName mocks base method.

--- a/test/mock/usecase/user.go
+++ b/test/mock/usecase/user.go
@@ -11,6 +11,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	uuid "github.com/google/uuid"
 )
 
 // MockUserUsecase is a mock of UserUsecase interface.
@@ -66,7 +67,7 @@ func (mr *MockUserUsecaseMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gom
 }
 
 // Update mocks base method.
-func (m *MockUserUsecase) Update(arg0 context.Context, arg1, arg2, arg3, arg4 string) (*dto.UserDTO, apierr.ApiError) {
+func (m *MockUserUsecase) Update(arg0 context.Context, arg1 uuid.UUID, arg2, arg3, arg4 string) (*dto.UserDTO, apierr.ApiError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*dto.UserDTO)

--- a/test/mock/usecase/user.go
+++ b/test/mock/usecase/user.go
@@ -53,7 +53,7 @@ func (mr *MockUserUsecaseMockRecorder) Create(arg0, arg1, arg2, arg3 interface{}
 }
 
 // Delete mocks base method.
-func (m *MockUserUsecase) Delete(arg0 context.Context, arg1, arg2 string) apierr.ApiError {
+func (m *MockUserUsecase) Delete(arg0 context.Context, arg1 uuid.UUID, arg2 string) apierr.ApiError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
 	ret0, _ := ret[0].(apierr.ApiError)


### PR DESCRIPTION
# Issue
- close: #18 

# 概要

Bearerトークンの認証を行うミドルウェアを作成.

ユーザーの更新と削除をBearerトークンの認証にて行い、URLパスパラメータからuser_nameを削除.