### PR TITLE
【CI/CD】APIをGitHub Container RegistryにデプロイするWorkflowを作成

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -35,5 +35,5 @@ jobs:
           platform: linux/amd64
           provenance: false
           tags: |
-            ghcr.io/${{ github.repository_owner }}/${GITHUB_REPOSITORY##*/}:latest
-            ghcr.io/${{ github.repository_owner }}/${GITHUB_REPOSITORY##*/}:1.0.0
+            ghcr.io/${{ github.repository_owner }}/holos-auth-api:latest
+            ghcr.io/${{ github.repository_owner }}/holos-auth-api:1.0.0


### PR DESCRIPTION
# Issue
- close: #23 

# 概要
GitHub Actions Workflow内GitHub Container Registryのリポジトリ名をハードコーディングに変更.