### PR TITLE
【User】ユーザー名更新時に重複確認を行う

### DIFF
--- a/internal/app/api/domain/repository/user.go
+++ b/internal/app/api/domain/repository/user.go
@@ -13,6 +13,6 @@ type UserRepository interface {
 	Create(context.Context, *entity.User) apierr.ApiError
 	Update(context.Context, *entity.User) apierr.ApiError
 	Delete(context.Context, *entity.User) apierr.ApiError
-	FindOneByID(context.Context, uuid.UUID) (*entity.User, apierr.ApiError)
+	FindOneByIDAndNotDeleted(context.Context, uuid.UUID) (*entity.User, apierr.ApiError)
 	FindOneByName(context.Context, string) (*entity.User, apierr.ApiError)
 }

--- a/internal/app/api/infrastructure/user.go
+++ b/internal/app/api/infrastructure/user.go
@@ -69,7 +69,7 @@ func (ui *userInfrastructure) Delete(ctx context.Context, user *entity.User) api
 	return nil
 }
 
-func (ui *userInfrastructure) FindOneByID(ctx context.Context, id uuid.UUID) (*entity.User, apierr.ApiError) {
+func (ui *userInfrastructure) FindOneByIDAndNotDeleted(ctx context.Context, id uuid.UUID) (*entity.User, apierr.ApiError) {
 	var user entity.User
 	driver := getSqlxDriver(ctx, ui.db)
 	if err := driver.QueryRowxContext(
@@ -91,7 +91,7 @@ func (ui *userInfrastructure) FindOneByName(ctx context.Context, name string) (*
 	driver := getSqlxDriver(ctx, ui.db)
 	if err := driver.QueryRowxContext(
 		ctx,
-		`SELECT id, name, password, created_at, updated_at FROM users WHERE name = ? AND deleted_at IS NULL LIMIT 1;`,
+		`SELECT id, name, password, created_at, updated_at FROM users WHERE name = ? LIMIT 1;`,
 		name,
 	).StructScan(&user); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/app/api/infrastructure/user_test.go
+++ b/internal/app/api/infrastructure/user_test.go
@@ -188,7 +188,7 @@ func TestUser_Delete(t *testing.T) {
 	}
 }
 
-func TestUser_FindOneByID(t *testing.T) {
+func TestUser_FindOneByIDAndNotDeleted(t *testing.T) {
 	tests := []struct {
 		id            uuid.UUID
 		name          string
@@ -243,7 +243,7 @@ func TestUser_FindOneByID(t *testing.T) {
 			if tt.isTransaction {
 				to := infrastructure.NewSqlxTransactionObject(db)
 				if err := to.Transaction(ctx, func(ctx context.Context) apierr.ApiError {
-					result, err := ui.FindOneByID(ctx, tt.id)
+					result, err := ui.FindOneByIDAndNotDeleted(ctx, tt.id)
 					if err != nil {
 						return err
 					}
@@ -255,7 +255,7 @@ func TestUser_FindOneByID(t *testing.T) {
 					t.Error(err.Error())
 				}
 			} else {
-				result, err := ui.FindOneByID(ctx, tt.id)
+				result, err := ui.FindOneByIDAndNotDeleted(ctx, tt.id)
 				if err != nil {
 					t.Error(err.Error())
 				}
@@ -303,7 +303,7 @@ func TestUser_FindOneByName(t *testing.T) {
 			if tt.isTransaction {
 				mock.ExpectBegin()
 			}
-			mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, password, created_at, updated_at FROM users WHERE name = ? AND deleted_at IS NULL LIMIT 1;")).
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, password, created_at, updated_at FROM users WHERE name = ? LIMIT 1;")).
 				WithArgs(tt.name).
 				WillReturnRows(
 					sqlmock.NewRows([]string{"id", "name", "password", "created_at", "updated_at"}).

--- a/internal/app/api/usecase/user.go
+++ b/internal/app/api/usecase/user.go
@@ -66,7 +66,7 @@ func (uu *userUsecase) UpdateName(ctx context.Context, id uuid.UUID, name string
 
 	if err := uu.transactionObject.Transaction(ctx, func(ctx context.Context) apierr.ApiError {
 		var err apierr.ApiError
-		user, err = uu.userRepository.FindOneByID(ctx, id)
+		user, err = uu.userRepository.FindOneByIDAndNotDeleted(ctx, id)
 		if err != nil {
 			return err
 		}
@@ -91,7 +91,7 @@ func (uu *userUsecase) UpdatePassword(ctx context.Context, id uuid.UUID, current
 
 	if err := uu.transactionObject.Transaction(ctx, func(ctx context.Context) apierr.ApiError {
 		var err apierr.ApiError
-		user, err = uu.userRepository.FindOneByID(ctx, id)
+		user, err = uu.userRepository.FindOneByIDAndNotDeleted(ctx, id)
 		if err != nil {
 			return err
 		}
@@ -117,7 +117,7 @@ func (uu *userUsecase) UpdatePassword(ctx context.Context, id uuid.UUID, current
 
 func (uu *userUsecase) Delete(ctx context.Context, id uuid.UUID, password string) apierr.ApiError {
 	return uu.transactionObject.Transaction(ctx, func(ctx context.Context) apierr.ApiError {
-		user, err := uu.userRepository.FindOneByID(ctx, id)
+		user, err := uu.userRepository.FindOneByIDAndNotDeleted(ctx, id)
 		if err != nil {
 			return err
 		}

--- a/internal/app/api/usecase/user.go
+++ b/internal/app/api/usecase/user.go
@@ -78,6 +78,12 @@ func (uu *userUsecase) UpdateName(ctx context.Context, id uuid.UUID, name string
 			return err
 		}
 
+		if exists, err := uu.userService.Exists(ctx, user); err != nil {
+			return err
+		} else if exists {
+			return ErrUserAlreadyExists
+		}
+
 		return uu.userRepository.Update(ctx, user)
 	}); err != nil {
 		return nil, err

--- a/internal/app/api/usecase/user_test.go
+++ b/internal/app/api/usecase/user_test.go
@@ -71,19 +71,29 @@ func TestUser_UpdateName(t *testing.T) {
 		id          uuid.UUID
 		name        string
 		isReturnNil bool
+		exists      bool
 		expect      apierr.ApiError
 	}{
 		{
 			id:          uuid.New(),
-			name:        "exists",
+			name:        "success",
 			isReturnNil: false,
+			exists:      false,
 			expect:      nil,
 		},
 		{
 			id:          uuid.New(),
-			name:        "not_exists",
+			name:        "user_notfound",
 			isReturnNil: true,
+			exists:      false,
 			expect:      usecase.ErrUserNotFound,
+		},
+		{
+			id:          uuid.New(),
+			name:        "exists",
+			isReturnNil: false,
+			exists:      true,
+			expect:      usecase.ErrUserAlreadyExists,
 		},
 	}
 	for _, tt := range tests {
@@ -110,6 +120,7 @@ func TestUser_UpdateName(t *testing.T) {
 			ur.EXPECT().Update(ctx, gomock.Any()).Return(nil).AnyTimes()
 
 			us := mock_service.NewMockUserService(ctrl)
+			us.EXPECT().Exists(gomock.Any(), user).Return(tt.exists, nil).AnyTimes()
 
 			uu := usecase.NewUserUsecase(to, ur, us)
 			dto, err := uu.UpdateName(ctx, tt.id, tt.name)

--- a/internal/app/api/usecase/user_test.go
+++ b/internal/app/api/usecase/user_test.go
@@ -23,13 +23,13 @@ func TestUser_Create(t *testing.T) {
 		expect   apierr.ApiError
 	}{
 		{
-			name:     "exists",
+			name:     "not_exists",
 			password: "password",
 			exists:   false,
 			expect:   nil,
 		},
 		{
-			name:     "not_exists",
+			name:     "exists",
 			password: "password",
 			exists:   true,
 			expect:   usecase.ErrUserAlreadyExists,
@@ -106,7 +106,7 @@ func TestUser_UpdateName(t *testing.T) {
 			to := test.NewTestTransactionObject()
 
 			ur := mock_repository.NewMockUserRepository(ctrl)
-			ur.EXPECT().FindOneByID(ctx, tt.id).Return(res, nil)
+			ur.EXPECT().FindOneByIDAndNotDeleted(ctx, tt.id).Return(res, nil)
 			ur.EXPECT().Update(ctx, gomock.Any()).Return(nil).AnyTimes()
 
 			us := mock_service.NewMockUserService(ctrl)
@@ -170,7 +170,7 @@ func TestUser_UpdatePassword(t *testing.T) {
 			to := test.NewTestTransactionObject()
 
 			ur := mock_repository.NewMockUserRepository(ctrl)
-			ur.EXPECT().FindOneByID(ctx, tt.id).Return(res, nil)
+			ur.EXPECT().FindOneByIDAndNotDeleted(ctx, tt.id).Return(res, nil)
 			ur.EXPECT().Update(ctx, gomock.Any()).Return(nil).AnyTimes()
 
 			us := mock_service.NewMockUserService(ctrl)
@@ -234,7 +234,7 @@ func TestUser_Delete(t *testing.T) {
 			to := test.NewTestTransactionObject()
 
 			ur := mock_repository.NewMockUserRepository(ctrl)
-			ur.EXPECT().FindOneByID(ctx, tt.id).Return(res, nil)
+			ur.EXPECT().FindOneByIDAndNotDeleted(ctx, tt.id).Return(res, nil)
 			ur.EXPECT().Delete(ctx, gomock.Any()).Return(nil).AnyTimes()
 
 			us := mock_service.NewMockUserService(ctrl)

--- a/test/mock/domain/repository/user.go
+++ b/test/mock/domain/repository/user.go
@@ -65,19 +65,19 @@ func (mr *MockUserRepositoryMockRecorder) Delete(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockUserRepository)(nil).Delete), arg0, arg1)
 }
 
-// FindOneByID mocks base method.
-func (m *MockUserRepository) FindOneByID(arg0 context.Context, arg1 uuid.UUID) (*entity.User, apierr.ApiError) {
+// FindOneByIDAndNotDeleted mocks base method.
+func (m *MockUserRepository) FindOneByIDAndNotDeleted(arg0 context.Context, arg1 uuid.UUID) (*entity.User, apierr.ApiError) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindOneByID", arg0, arg1)
+	ret := m.ctrl.Call(m, "FindOneByIDAndNotDeleted", arg0, arg1)
 	ret0, _ := ret[0].(*entity.User)
 	ret1, _ := ret[1].(apierr.ApiError)
 	return ret0, ret1
 }
 
-// FindOneByID indicates an expected call of FindOneByID.
-func (mr *MockUserRepositoryMockRecorder) FindOneByID(arg0, arg1 interface{}) *gomock.Call {
+// FindOneByIDAndNotDeleted indicates an expected call of FindOneByIDAndNotDeleted.
+func (mr *MockUserRepositoryMockRecorder) FindOneByIDAndNotDeleted(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneByID", reflect.TypeOf((*MockUserRepository)(nil).FindOneByID), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneByIDAndNotDeleted", reflect.TypeOf((*MockUserRepository)(nil).FindOneByIDAndNotDeleted), arg0, arg1)
 }
 
 // FindOneByName mocks base method.


### PR DESCRIPTION
# Issue
- close: #38 

# 概要
UserUsecaseのUpdateName関数内でExists関数を用いたユーザーの重複確認処理を追加.

UserInfrastructureのFindOneByName関数からdeleted_at IS NULL判定を削除.
UserInfrastructureのFindOneByID関数をFindOneByIDAndNotDeletedに変名.