### PR TITLE
【Agent】AgentInfrastructureの削除判定を修正

### DIFF
--- a/internal/app/api/domain/repository/agent.go
+++ b/internal/app/api/domain/repository/agent.go
@@ -13,6 +13,6 @@ type AgentRepository interface {
 	Create(context.Context, *entity.Agent) apierr.ApiError
 	Update(context.Context, *entity.Agent) apierr.ApiError
 	Delete(context.Context, *entity.Agent) apierr.ApiError
-	FindOneByIDAndUserID(context.Context, uuid.UUID, uuid.UUID) (*entity.Agent, apierr.ApiError)
+	FindOneByIDAndUserIDAndNotDeleted(context.Context, uuid.UUID, uuid.UUID) (*entity.Agent, apierr.ApiError)
 	FindOneByUserIDAndName(context.Context, uuid.UUID, string) (*entity.Agent, apierr.ApiError)
 }

--- a/internal/app/api/infrastructure/agent.go
+++ b/internal/app/api/infrastructure/agent.go
@@ -82,7 +82,7 @@ func (ai *agentInfrastructure) FindOneByUserIDAndName(ctx context.Context, userI
 	driver := getSqlxDriver(ctx, ai.db)
 	if err := driver.QueryRowxContext(
 		ctx,
-		`SELECT id, user_id, name, created_at, updated_at FROM agents WHERE user_id = ? AND name = ? AND deleted_at IS NULL LIMIT 1;`,
+		`SELECT id, user_id, name, created_at, updated_at FROM agents WHERE user_id = ? AND name = ? LIMIT 1;`,
 		userID,
 		name,
 	).StructScan(&agent); err != nil {

--- a/internal/app/api/infrastructure/agent.go
+++ b/internal/app/api/infrastructure/agent.go
@@ -59,7 +59,7 @@ func (ai *agentInfrastructure) Delete(ctx context.Context, agent *entity.Agent) 
 	return nil
 }
 
-func (ai *agentInfrastructure) FindOneByIDAndUserID(ctx context.Context, id uuid.UUID, userID uuid.UUID) (*entity.Agent, apierr.ApiError) {
+func (ai *agentInfrastructure) FindOneByIDAndUserIDAndNotDeleted(ctx context.Context, id uuid.UUID, userID uuid.UUID) (*entity.Agent, apierr.ApiError) {
 	var agent entity.Agent
 	driver := getSqlxDriver(ctx, ai.db)
 	if err := driver.QueryRowxContext(

--- a/internal/app/api/infrastructure/agent_test.go
+++ b/internal/app/api/infrastructure/agent_test.go
@@ -176,7 +176,7 @@ func TestAgent_Delete(t *testing.T) {
 	}
 }
 
-func TestAgent_FindOneByIDAndUserID(t *testing.T) {
+func TestAgent_FindOneByIDAndUserIDAndNotDeleted(t *testing.T) {
 	tests := []struct {
 		id            uuid.UUID
 		userID        uuid.UUID
@@ -235,7 +235,7 @@ func TestAgent_FindOneByIDAndUserID(t *testing.T) {
 			if tt.isTransaction {
 				to := infrastructure.NewSqlxTransactionObject(db)
 				if err := to.Transaction(ctx, func(ctx context.Context) apierr.ApiError {
-					result, err := ai.FindOneByIDAndUserID(ctx, tt.id, tt.userID)
+					result, err := ai.FindOneByIDAndUserIDAndNotDeleted(ctx, tt.id, tt.userID)
 					if err != nil {
 						return err
 					}
@@ -247,7 +247,7 @@ func TestAgent_FindOneByIDAndUserID(t *testing.T) {
 					t.Error(err.Error())
 				}
 			} else {
-				result, err := ai.FindOneByIDAndUserID(ctx, tt.id, tt.userID)
+				result, err := ai.FindOneByIDAndUserIDAndNotDeleted(ctx, tt.id, tt.userID)
 				if err != nil {
 					t.Error(err.Error())
 				}

--- a/internal/app/api/infrastructure/agent_test.go
+++ b/internal/app/api/infrastructure/agent_test.go
@@ -303,7 +303,7 @@ func TestAgent_FindOneByUserIDAndName(t *testing.T) {
 			if tt.isTransaction {
 				mock.ExpectBegin()
 			}
-			mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, name, created_at, updated_at FROM agents WHERE user_id = ? AND name = ? AND deleted_at IS NULL LIMIT 1;")).
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id, name, created_at, updated_at FROM agents WHERE user_id = ? AND name = ? LIMIT 1;")).
 				WithArgs(tt.userID, tt.name).
 				WillReturnRows(
 					sqlmock.NewRows([]string{"id", "user_id", "name", "created_at", "updated_at"}).

--- a/internal/app/api/usecase/agent.go
+++ b/internal/app/api/usecase/agent.go
@@ -65,7 +65,7 @@ func (au *agentUsecase) Update(ctx context.Context, id uuid.UUID, userID uuid.UU
 
 	if err := au.transactionObject.Transaction(ctx, func(ctx context.Context) apierr.ApiError {
 		var err apierr.ApiError
-		agent, err = au.agentRepository.FindOneByIDAndUserID(ctx, id, userID)
+		agent, err = au.agentRepository.FindOneByIDAndUserIDAndNotDeleted(ctx, id, userID)
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ func (au *agentUsecase) Update(ctx context.Context, id uuid.UUID, userID uuid.UU
 
 func (au *agentUsecase) Delete(ctx context.Context, id uuid.UUID, userID uuid.UUID) apierr.ApiError {
 	return au.transactionObject.Transaction(ctx, func(ctx context.Context) apierr.ApiError {
-		agent, err := au.agentRepository.FindOneByIDAndUserID(ctx, id, userID)
+		agent, err := au.agentRepository.FindOneByIDAndUserIDAndNotDeleted(ctx, id, userID)
 		if err != nil {
 			return err
 		}

--- a/internal/app/api/usecase/agent_test.go
+++ b/internal/app/api/usecase/agent_test.go
@@ -117,7 +117,7 @@ func TestAgent_Update(t *testing.T) {
 			to := test.NewTestTransactionObject()
 
 			ar := mock_repository.NewMockAgentRepository(ctrl)
-			ar.EXPECT().FindOneByIDAndUserID(ctx, tt.id, tt.userID).Return(res, nil)
+			ar.EXPECT().FindOneByIDAndUserIDAndNotDeleted(ctx, tt.id, tt.userID).Return(res, nil)
 			ar.EXPECT().Update(ctx, gomock.Any()).Return(nil).AnyTimes()
 
 			as := mock_service.NewMockAgentService(ctrl)
@@ -182,7 +182,7 @@ func TestAgent_Delete(t *testing.T) {
 			to := test.NewTestTransactionObject()
 
 			ar := mock_repository.NewMockAgentRepository(ctrl)
-			ar.EXPECT().FindOneByIDAndUserID(ctx, tt.id, tt.userID).Return(res, nil)
+			ar.EXPECT().FindOneByIDAndUserIDAndNotDeleted(ctx, tt.id, tt.userID).Return(res, nil)
 			ar.EXPECT().Delete(ctx, gomock.Any()).Return(nil).AnyTimes()
 
 			as := mock_service.NewMockAgentService(ctrl)

--- a/test/mock/domain/repository/agent.go
+++ b/test/mock/domain/repository/agent.go
@@ -65,19 +65,19 @@ func (mr *MockAgentRepositoryMockRecorder) Delete(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockAgentRepository)(nil).Delete), arg0, arg1)
 }
 
-// FindOneByIDAndUserID mocks base method.
-func (m *MockAgentRepository) FindOneByIDAndUserID(arg0 context.Context, arg1, arg2 uuid.UUID) (*entity.Agent, apierr.ApiError) {
+// FindOneByIDAndUserIDAndNotDeleted mocks base method.
+func (m *MockAgentRepository) FindOneByIDAndUserIDAndNotDeleted(arg0 context.Context, arg1, arg2 uuid.UUID) (*entity.Agent, apierr.ApiError) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindOneByIDAndUserID", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "FindOneByIDAndUserIDAndNotDeleted", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*entity.Agent)
 	ret1, _ := ret[1].(apierr.ApiError)
 	return ret0, ret1
 }
 
-// FindOneByIDAndUserID indicates an expected call of FindOneByIDAndUserID.
-func (mr *MockAgentRepositoryMockRecorder) FindOneByIDAndUserID(arg0, arg1, arg2 interface{}) *gomock.Call {
+// FindOneByIDAndUserIDAndNotDeleted indicates an expected call of FindOneByIDAndUserIDAndNotDeleted.
+func (mr *MockAgentRepositoryMockRecorder) FindOneByIDAndUserIDAndNotDeleted(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneByIDAndUserID", reflect.TypeOf((*MockAgentRepository)(nil).FindOneByIDAndUserID), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneByIDAndUserIDAndNotDeleted", reflect.TypeOf((*MockAgentRepository)(nil).FindOneByIDAndUserIDAndNotDeleted), arg0, arg1, arg2)
 }
 
 // FindOneByUserIDAndName mocks base method.


### PR DESCRIPTION
# Issue
- close: #42 

# 概要

AgentInfrastructureのFindOneByUserIDAndName関数からdeleted_at IS NULL判定を削除.
AgentInfrastructureのFindOneByIDAndUserID関数をFindOneByIDAndUserIDAndNotDeletedに変名.