### PR TITLE
【認証】ユーザートークンモデルを作成

### DIFF
--- a/internal/app/api/domain/entity/user_token.go
+++ b/internal/app/api/domain/entity/user_token.go
@@ -13,9 +13,9 @@ import (
 var ErrUserTokenTooLong = apierr.NewApiError(http.StatusInternalServerError, "user token must be 32 characters or less")
 
 type UserToken struct {
-	UserID    uuid.UUID `db:"user_id"`
-	Token     string    `db:"token"`
-	ExpiresAt time.Time `db:"expires_at"`
+	UserID    uuid.UUID
+	Token     string
+	ExpiresAt time.Time
 }
 
 func NewUserToken(userID uuid.UUID) (*UserToken, apierr.ApiError) {
@@ -29,6 +29,14 @@ func NewUserToken(userID uuid.UUID) (*UserToken, apierr.ApiError) {
 		Token:     token,
 		ExpiresAt: time.Now().Add(time.Hour * 24 * 30),
 	}, nil
+}
+
+func RestoreUserToken(userID uuid.UUID, token string, expiresAt time.Time) *UserToken {
+	return &UserToken{
+		UserID:    userID,
+		Token:     token,
+		ExpiresAt: expiresAt,
+	}
 }
 
 func generateToken() (string, apierr.ApiError) {

--- a/internal/app/api/infrastructure/model/user_token.go
+++ b/internal/app/api/infrastructure/model/user_token.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type UserTokenModel struct {
+	UserID    uuid.UUID `db:"user_id"`
+	Token     string    `db:"token"`
+	ExpiresAt time.Time `db:"expires_at"`
+}
+
+func NewUserTokenModel(userID uuid.UUID, token string, expiresAt time.Time) *UserTokenModel {
+	return &UserTokenModel{
+		UserID:    userID,
+		Token:     token,
+		ExpiresAt: expiresAt,
+	}
+}


### PR DESCRIPTION
# Issue
- close: #48 

# 概要
Infrastructure層にユーザートークンモデルを作成し、entity復元関数を作成.