### PR TITLE
【Agent】認証情報作成のレスポンス型を修正 #118

### DIFF
--- a/internal/app/api/interface/handler/agent.go
+++ b/internal/app/api/interface/handler/agent.go
@@ -284,7 +284,7 @@ func (h *agentHandler) GenerateToken(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, token)
+	c.String(http.StatusOK, token)
 }
 
 func (h *agentHandler) DeleteToken(c *gin.Context) {


### PR DESCRIPTION
# Issue
- close: #118 

# 概要
**AgentToken作成時のレスポンスがJSONになっているため、Stringに修正.